### PR TITLE
Fix gradle build error on Android Studio

### DIFF
--- a/BaseGameUtils/build.gradle
+++ b/BaseGameUtils/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {


### PR DESCRIPTION
After importing the project I was not able to Gradle sync the project on Android Studio, which was giving me: 

ERROR: Could not find com.android.tools.build:gradle:3.2.1.
Searched in the following locations:
    https://jcenter.bintray.com/com/android/tools/build/gradle/3.2.1/gradle-3.2.1.pom
    https://jcenter.bintray.com/com/android/tools/build/gradle/3.2.1/gradle-3.2.1.jar
Required by:
    project :BaseGameUtils

I created this PR in order to fix this issue.
Android Studio version as below.

Android Studio 3.3.1
Build #AI-182.5107.16.33.5264788, built on January 28, 2019
JRE: 1.8.0_152-release-1248-b01 amd64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Windows 10 10.0